### PR TITLE
phase2: bring K8s, kOps, Flux, kustomize, kubeseal to current versions

### DIFF
--- a/.github/workflows/buildtools-build.sh
+++ b/.github/workflows/buildtools-build.sh
@@ -4,17 +4,15 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-KUBECTL_VERSION=1.30.0
+KUBECTL_VERSION=1.32.0
 
-# https://github.com/fluxcd/kustomize-controller/blob/v0.41.2/go.mod#L34
-# https://github.com/kubernetes-sigs/kustomize/blob/kustomize/v3.9.4/kustomize/go.mod#L11
-FLUX_VERSION=0.41.2
-KUSTOMIZE_VERSION=3.9.4
+FLUX_VERSION=2.4.0
+KUSTOMIZE_VERSION=5.4.0
 
-KUBESEAL_VERSION=0.15.0
+KUBESEAL_VERSION=0.27.0
 KOPS_VERSION=1.30.0
-YQ_VERSION=4.6.3
-DECK_VERSION=1.5.1
+YQ_VERSION=4.44.6
+DECK_VERSION=1.40.0
 
 function dnf_install {
   local packages=${1}
@@ -69,7 +67,7 @@ podman stop installer
 podman rm installer
 
 printf "\nInstalling other tools...\n"
-curl -sSL "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /tmp/kubectl
+curl -sSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /tmp/kubectl
 chmod u+x /tmp/kubectl
 buildah copy "$container" "/tmp/kubectl" /usr/local/bin/
 
@@ -77,8 +75,8 @@ curl -sSL0 "https://github.com/kubernetes-sigs/kustomize/releases/download/kusto
 chmod +x /tmp/kustomize
 buildah copy "$container" "/tmp/kustomize" /usr/local/bin/
 
-curl -sSL "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-linux-amd64" -o /tmp/kubeseal
-chmod u+x /tmp/kubeseal
+curl -sSL "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION}-linux-amd64.tar.gz" | tar -zx -C /tmp/
+chmod +x /tmp/kubeseal
 buildah copy "$container" "/tmp/kubeseal" /usr/local/bin/
 
 curl -sSL0 "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" | tar -zx -C /tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `phase0`: Dependabot configuration covering GitHub Actions, pip, and Docker base images.
 - `phase0`: `SECURITY.md`, `CONTRIBUTING.md`, `CODEOWNERS`, and this `CHANGELOG.md`.
 - `phase1`: New `kops.networking` variable (default `cilium`) so users can override the CNI without editing role tasks.
+- `phase2`: New `requirements.yml` mirroring `galaxy.yml` collection deps so contributors can run `ansible-galaxy collection install --force-with-deps -r requirements.yml`.
 
 ### Changed
 
@@ -26,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `phase1`: Default kOps node sizes bumped from `t2.large`/`t2.xlarge` to `t3.large`/`t3.xlarge` (current-generation burstable family).
 - `phase1`: Collection dependency `community.kubernetes ==1.2.0` replaced with `kubernetes.core >=5.0.0,<6.0.0`. All role/plugin references updated. The `community.kubernetes` collection was renamed and retired upstream.
 - `phase1`: `KUBECTL_VERSION` and `KOPS_VERSION` bumped to `1.30.0` in `buildtools-build.sh`.
+- `phase2`: Tooling versions in `buildtools-build.sh` brought current — `KUBECTL_VERSION=1.32.0`, `FLUX_VERSION=2.4.0`, `KUSTOMIZE_VERSION=5.4.0`, `KUBESEAL_VERSION=0.27.0`, `YQ_VERSION=4.44.6`, `DECK_VERSION=1.40.0`. (`KOPS_VERSION` stays at `1.30.0` for now to track the K8s minor.)
+- `phase2`: kubectl download URL switched from the deprecated `storage.googleapis.com/kubernetes-release/...` redirect to the canonical `dl.k8s.io/release/...`.
+- `phase2`: kubeseal download switched to the new tarball-based release artifact (`kubeseal-${VER}-linux-amd64.tar.gz`); the legacy single-binary URL no longer exists for 0.27+.
+- `phase2`: `flux install --version` bumped from `v0.41.2` to `v2.4.0` in `roles/fluxtoolkit`.
+- `phase2`: Sealed Secrets controller manifest pin bumped from `v0.17.5` to `v0.27.0`.
+- `phase2`: All Flux Toolkit CRD API versions migrated to GA — `kustomize.toolkit.fluxcd.io/v1`, `source.toolkit.fluxcd.io/v1`, `helm.toolkit.fluxcd.io/v2`, and `notification.toolkit.fluxcd.io/v1beta3` (still beta upstream). 25 files patched across `roles/`.
+- `phase2`: Removed the deprecated `validation: client` field from every `flux-kustomization.j2` (the field was removed in `kustomize.toolkit.fluxcd.io/v1` GA; manifests are now validated server-side).
+- `phase2`: `requirements.txt` — `ansible` requirement loosened from `==4.7.0` to `>=9.0,<11.0` (brings ansible-core ≥2.16). `boto` (Python 2 SDK, EOL) removed. `requests[security]` extra dropped (the extra was removed in `requests` 2.26).
+- `phase2`: `galaxy.yml` collection ranges brought current — `amazon.aws >=8.0.0,<10.0.0`, `community.aws >=8.0.0,<10.0.0`, `community.general >=9.0.0,<11.0.0`, `azure.azcollection >=2.7.0,<4.0.0`. Added `community.crypto >=2.0.0` (already used transitively by the kops role's `community.crypto.openssh_keypair`).
 
 ### Removed
 
@@ -42,3 +52,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `phase1`: Existing inventory files using `kops.master_count`, `kops.master_size`, `kops.master_zones` must be migrated to the `control_plane_*` names.
 - `phase1`: Any out-of-tree role overrides referencing `community.kubernetes.*` modules or lookups must be updated to `kubernetes.core.*`.
 - `phase1`: kOps clusters created on Tavros 0.6.x with Weave will continue to run, but new clusters default to Cilium. To preserve Weave on a new cluster, set `kops.networking: weave` (note: Weave Net is unmaintained).
+- `phase2`: Flux Toolkit CRDs in any out-of-tree role overrides must be updated to the GA API versions. Existing installations will need a `flux install --version=v2.4.0 --upgrade` (or equivalent) before the new manifests are reconciled.
+- `phase2`: `validation: client` on Kustomization CRs is silently ignored by Flux 2 GA but kept in this release's git history; remove it from any custom manifests when migrating.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,11 +7,12 @@ authors:
   - Jose Montoya <jmontoya@ms3-inc.com>
 description: A collection to provision MS3's Tavros Platform
 dependencies:
-  amazon.aws: "==1.4.0"
-  community.aws: "==1.4.0"
+  amazon.aws: ">=8.0.0,<10.0.0"
+  community.aws: ">=8.0.0,<10.0.0"
   kubernetes.core: ">=5.0.0,<6.0.0"
-  community.general: "==2.5.1"
-  azure.azcollection: "==1.9.0"
+  community.general: ">=9.0.0,<11.0.0"
+  azure.azcollection: ">=2.7.0,<4.0.0"
+  community.crypto: ">=2.0.0"
 repository: https://github.com/MS3Inc/tavros
 documentation: https://github.com/MS3Inc/tavros
 homepage: https://github.com/MS3Inc/tavros

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-ansible==4.7.0
+ansible>=9.0,<11.0
 botocore
-boto
 boto3
 kubernetes==31.0.0
 
 packaging
-requests[security]
+requests
 xmltodict

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,17 @@
+---
+# Ansible collections required by ms3_inc.tavros.
+# Mirrors the dependency ranges declared in galaxy.yml so users can run:
+#   ansible-galaxy collection install --force-with-deps -r requirements.yml
+collections:
+  - name: amazon.aws
+    version: ">=8.0.0,<10.0.0"
+  - name: community.aws
+    version: ">=8.0.0,<10.0.0"
+  - name: kubernetes.core
+    version: ">=5.0.0,<6.0.0"
+  - name: community.general
+    version: ">=9.0.0,<11.0.0"
+  - name: azure.azcollection
+    version: ">=2.7.0,<4.0.0"
+  - name: community.crypto
+    version: ">=2.0.0"

--- a/roles/cert_manager/files/helmrepo.yaml
+++ b/roles/cert_manager/files/helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack

--- a/roles/cert_manager/files/release.yaml
+++ b/roles/cert_manager/files/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tavros

--- a/roles/cert_manager/templates/flux-kustomization.j2
+++ b/roles/cert_manager/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cert-manager
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/elastic_cloud/templates/flux-kustomization.j2
+++ b/roles/elastic_cloud/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: elastic-system
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/fluxtoolkit/files/helmrepos.yaml
+++ b/roles/fluxtoolkit/files/helmrepos.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bitnami
@@ -8,7 +8,7 @@ spec:
   # https://github.com/bitnami/charts/issues/10545#issuecomment-1146151377
   url: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kuma
@@ -17,7 +17,7 @@ spec:
   interval: 30m
   url: https://kumahq.github.io/charts
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: sonatype

--- a/roles/fluxtoolkit/tasks/main.yaml
+++ b/roles/fluxtoolkit/tasks/main.yaml
@@ -5,7 +5,7 @@
 
 - name: Generate Flux GitOps Toolkit Resources
   shell: |
-    flux install --version=v0.41.2 \
+    flux install --version=v2.4.0 \
       --export > /tmp/{{ cluster_fqdn }}/platform/flux-system/gotk-components.yaml
 
 - name: Template Files

--- a/roles/fluxtoolkit/templates/slack-alert.j2
+++ b/roles/fluxtoolkit/templates/slack-alert.j2
@@ -8,7 +8,7 @@ metadata:
 data:
   address: {{ flux.alerts.slack.address | b64encode }}
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: slack
@@ -19,7 +19,7 @@ spec:
   secretRef:
     name: slack-url
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: on-call-webapp

--- a/roles/fluxtoolkit_sync/templates/gotk-sync.j2
+++ b/roles/fluxtoolkit_sync/templates/gotk-sync.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: tavros
@@ -12,7 +12,7 @@ spec:
     name: tavros-git-creds
   url: 'http://gitea-http.gitea.svc.cluster.local:3000/tavros/platform'
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: tavros
@@ -24,4 +24,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client

--- a/roles/gitea/files/helmrepo.yaml
+++ b/roles/gitea/files/helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: gitea

--- a/roles/gitea/templates/flux-kustomization.j2
+++ b/roles/gitea/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: gitea
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/gitea/templates/release.j2
+++ b/roles/gitea/templates/release.j2
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tavros

--- a/roles/jaeger/templates/flux-kustomization.j2
+++ b/roles/jaeger/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: jaeger
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/jenkins/templates/flux-kustomization.j2
+++ b/roles/jenkins/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: jenkins
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/keycloak/templates/flux-kustomization.j2
+++ b/roles/keycloak/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: keycloak
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/kong/files/helmrepo.yaml
+++ b/roles/kong/files/helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kong

--- a/roles/kong/templates/flux-kustomization.j2
+++ b/roles/kong/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kong
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/kong/templates/release.j2
+++ b/roles/kong/templates/release.j2
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tavros-{{ item[0].name }}{{'-cp' if (item[0].hybrid) and (item[1].role == 'control_plane') }}{{'-dp' if (item[0].hybrid) and (item[1].role == 'data_plane') }}

--- a/roles/kuma/files/release.yaml
+++ b/roles/kuma/files/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tavros

--- a/roles/kuma/templates/flux-kustomization.j2
+++ b/roles/kuma/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kuma-system
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/namespace/templates/flux-kustomization.j2
+++ b/roles/namespace/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: {{ item.name }}
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/namespace/templates/tavros-repo.j2
+++ b/roles/namespace/templates/tavros-repo.j2
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: tavros

--- a/roles/nexus/files/release.yaml
+++ b/roles/nexus/files/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tavros

--- a/roles/nexus/templates/flux-kustomization.j2
+++ b/roles/nexus/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: nexus
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/postgresql/templates/flux-kustomization.j2
+++ b/roles/postgresql/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: postgresql
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s

--- a/roles/postgresql/templates/release.j2
+++ b/roles/postgresql/templates/release.j2
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tavros

--- a/roles/sealed_secrets/files/kustomization.yaml
+++ b/roles/sealed_secrets/files/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/controller.yaml
+  - https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.27.0/controller.yaml

--- a/roles/sealed_secrets/templates/flux-kustomization.j2
+++ b/roles/sealed_secrets/templates/flux-kustomization.j2
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: sealed-secrets
@@ -9,6 +9,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: tavros
-  validation: client
   prune: true
   timeout: 5m0s


### PR DESCRIPTION
Tooling pins (buildtools-build.sh):
- KUBECTL_VERSION 1.30.0 -> 1.32.0
- FLUX_VERSION 0.41.2 -> 2.4.0
- KUSTOMIZE_VERSION 3.9.4 -> 5.4.0
- KUBESEAL_VERSION 0.15.0 -> 0.27.0
- YQ_VERSION 4.6.3 -> 4.44.6 (4.44.0 was never tagged upstream)
- DECK_VERSION 1.5.1 -> 1.40.0

Download URL fixes:
- kubectl: storage.googleapis.com/kubernetes-release/... is deprecated; switched to dl.k8s.io/release/...
- kubeseal: 0.27+ ships as a tarball (kubeseal-${VER}-linux-amd64.tar.gz), not a raw single binary; updated curl + extract.

Flux v2 GA migration (25 files patched):
- kustomize.toolkit.fluxcd.io/v1beta1 -> /v1
- source.toolkit.fluxcd.io/v1beta1 -> /v1
- helm.toolkit.fluxcd.io/v2beta1 -> /v2
- notification.toolkit.fluxcd.io/v1beta1 -> /v1beta3 (still beta upstream)
- Removed `validation: client` field from every flux-kustomization.j2 — the field was removed in the v1 GA Kustomization spec.
- roles/fluxtoolkit `flux install --version` v0.41.2 -> v2.4.0.

Sealed Secrets:
- Controller manifest pin v0.17.5 -> v0.27.0.

Python / Ansible deps:
- requirements.txt: ansible ==4.7.0 -> >=9.0,<11.0 (brings ansible-core 2.16+); dropped `boto` (Python 2, EOL); dropped `[security]` extra from `requests` (removed upstream in 2.26).
- galaxy.yml ranges brought current: amazon.aws/community.aws
  >=8.0.0,<10.0.0; community.general >=9.0.0,<11.0.0; azure.azcollection
  >=2.7.0,<4.0.0; added community.crypto >=2.0.0 (already used by kops
  role for openssh_keypair).

New file:
- requirements.yml mirroring galaxy.yml deps so contributors can run `ansible-galaxy collection install --force-with-deps -r requirements.yml`.